### PR TITLE
readObject improvement.

### DIFF
--- a/src/main/java/com/github/ricpacca/magicset/MagicHashSet.java
+++ b/src/main/java/com/github/ricpacca/magicset/MagicHashSet.java
@@ -124,8 +124,8 @@ public class MagicHashSet<E extends UniqueItem> extends AbstractSet<E> implement
         map = new HashMap<>();
 
         map = (this) instanceof LinkedMagicHashSet ?
-                new LinkedHashMap<>() :
-                new HashMap<>();
+                new LinkedHashMap<>(size) :
+                new HashMap<>(size);
 
         // Read in all elements in the proper order.
         for (int i=0; i<size; i++) {


### PR DESCRIPTION
When we're reading the object in `readObject`, we know the `size` so use it for `initialCapacity` parameter of the underlying `HashMap` or `LinkedHashMap` constructors